### PR TITLE
Fix submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "homebrew_launcher_installer"]
 	path = homebrew_launcher_installer
-	url = git@github.com:wiiu-env/homebrew_launcher_installer.git
+	url = https://github.com/wiiu-env/homebrew_launcher_installer.git


### PR DESCRIPTION
This fixes the following issue:
```
$ git submodule update
Klone nach '/home/v10lator/git/HBLInstallerWrapper/homebrew_launcher_installer' ...
The authenticity of host 'github.com (140.82.121.4)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Konnte nicht vom Remote-Repository lesen.

Bitte stellen Sie sicher, dass die korrekten Zugriffsberechtigungen bestehen
und das Repository existiert.
fatal: Klonen von 'git@github.com:wiiu-env/homebrew_launcher_installer.git' in Submodul-Pfad '/home/v10lator/git/HBLInstallerWrapper/homebrew_launcher_installer' fehlgeschlagen.
Fehler beim Klonen von 'homebrew_launcher_installer'. Weiterer Versuch geplant
Klone nach '/home/v10lator/git/HBLInstallerWrapper/homebrew_launcher_installer' ...
git@github.com: Permission denied (publickey).
fatal: Konnte nicht vom Remote-Repository lesen.

Bitte stellen Sie sicher, dass die korrekten Zugriffsberechtigungen bestehen
und das Repository existiert.
fatal: Klonen von 'git@github.com:wiiu-env/homebrew_launcher_installer.git' in Submodul-Pfad '/home/v10lator/git/HBLInstallerWrapper/homebrew_launcher_installer' fehlgeschlagen.
Zweiter Versuch 'homebrew_launcher_installer' zu klonen fehlgeschlagen, breche ab.
```