### PR TITLE
Fix .rpx loading in HBL Channel.

### DIFF
--- a/source/hbl_install.cpp
+++ b/source/hbl_install.cpp
@@ -117,6 +117,7 @@ void InstallHBL() {
 
     unsigned int bufferU32 = 0x48000003 | jump_addr;
     KernelWriteU32(repl_addr, bufferU32);
+    MAIN_ENTRY_ADDR = 0xDEADC0DE;
 }
 
 /*


### PR DESCRIPTION
This fixes the need to load a .elf homebrew before being able to load a .rpx homebrew with @GaryOderNichts https://github.com/GaryOderNichts/homebrew_launcher/releases/tag/v2.1_fix

Note that this fix is quick&dirty and without me understanding the impact, so reviewing is highly recommended.

Fix confirmed to work by @vaguerant